### PR TITLE
reproducibly randomize order of input pixfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,9 @@ let n=68*$SLURM_JOB_NUM_NODES
 srun -n $n -c 4 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inputs/ -o $SCRATCH/temp
 ```
 
+Optional, to reduce the logging verbosity for large scale runs, change
+the logging level before running `desi-extract`:
+```
+export DESI_LOGLEVEL=error
+```
+

--- a/desi-extract
+++ b/desi-extract
@@ -24,6 +24,8 @@ args = parser.parse_args()
 from mpi4py import MPI
 from desispec.scripts import extract
 import sys, os, glob, socket
+import random
+random.seed(1)
 
 comm = MPI.COMM_WORLD
 rank = comm.rank
@@ -42,6 +44,7 @@ nframe = size // bundles_per_frame
 if rank == 0:
     assert os.path.exists(args.outdir)
     pixfiles = sorted(glob.glob(args.indir + '/pix/*/pix*.fits'))
+    random.shuffle(pixfiles)
     assert len(pixfiles) > 0
     assert nframe <= len(pixfiles)
     pixfiles = pixfiles[0:nframe]


### PR DESCRIPTION
Shuffle the order of the input pixfiles to get a mix of b,r,z channels and exposures rather than having smaller tests use only b-channel.