### PR TITLE
Reorganize imports a little, adjust timing

### DIFF
--- a/create-batch-script.py
+++ b/create-batch-script.py
@@ -59,6 +59,10 @@ def parse_arguments():
     parser.add_argument("--datadir", "-d",
             default = "/project/projectdirs/m888/www/apex/desi/benchmark/",
             help = "input data root directory")
+    parser.add_argument("--camera", "-c",
+            choices = ["b", "r", "z"],
+            default = None,
+            help = "channel selection")
     parser.add_argument("--script-name", "-S",
             default = None,
             help = "script name (from job name if None)")

--- a/desi-extract
+++ b/desi-extract
@@ -4,17 +4,26 @@
 DESI spectral extraction code benchmark
 
 salloc -N 5 -t 2:00:00 -C haswell -q interactive
-srun -n 160 -c 2 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inputs/ -o $SCRATCH/temp
+srun -n 160 -c 2 --cpu_bind=cores ./desi-extract -i $SCRATCH/desi/benchmark/inputs/ -o $SCRATCH/temp $(date +%s)
 """
 
-#- Get timer going ASAP
-import time
-start_time = time.time()
-str_start_time = time.asctime()
-
-#- Then parse args before initializing MPI so that --help will work anywhere
 import argparse
+import glob 
+import os
+import pprint
+import socket
+import random
+import sys
+import time
+
+from desispec.scripts import extract
+
+random.seed(1)
+
+#- Parse args before initializing MPI so that --help will work anywhere
+
 parser = argparse.ArgumentParser(usage = "{prog} [options]")
+parser.add_argument("start_time", type=float, help="$(date +%s)")
 parser.add_argument("-i", "--indir", type=str, required=True, help="input data directory")
 parser.add_argument("-o", "--outdir", type=str, required=True, help="output directory")
 parser.add_argument("-c", "--camera", type=str, choices=["b", "r", "z"], help="channel selection", default=None)
@@ -23,10 +32,6 @@ parser.add_argument("-c", "--camera", type=str, choices=["b", "r", "z"], help="c
 args = parser.parse_args()
 
 from mpi4py import MPI
-from desispec.scripts import extract
-import sys, os, glob, socket
-import random
-random.seed(1)
 
 comm = MPI.COMM_WORLD
 rank = comm.rank
@@ -34,9 +39,8 @@ size = comm.size
 
 comm.barrier()
 if rank == 0:
+    start_time = args.start_time
     startup_time = time.time() - start_time
-    print('Started at {}'.format(str_start_time))
-    print('python startup time: {:.1f} sec'.format(startup_time))
 
 bundles_per_frame = 20
 assert size % bundles_per_frame == 0, 'MPI size {} should be multiple of {}'.format(size, bundles_per_frame)
@@ -115,9 +119,9 @@ if rank == 0:
     node_hours = num_nodes * (end_time - start_time) / (60*60)
     work_rate = nframe / node_hours
 
-    print('{} frames in {:.1f} min'.format(nframe, (end_time - start_time)/60))
-    print('Work rate = {:.2f} frames per node-hour'.format(work_rate))
-    import pprint
     pprint.pprint(timings)
 
-
+    print('desi-extract {} effective frames in {:.1f} min'.format(nframe, (end_time - start_time)/60))
+    print('desi-extract effective work rate = {:.2f} frames per node-hour'.format(work_rate))
+    print('desi-extract startup time: {:.1f} sec'.format(startup_time))
+    print('desi-extract elapsed time: {:.1f} sec'.format(end_time - start_time))

--- a/desi-extract
+++ b/desi-extract
@@ -22,10 +22,10 @@ random.seed(1)
 
 #- Parse args before initializing MPI so that --help will work anywhere
 
-parser = argparse.ArgumentParser(usage = "{prog} [options]")
-parser.add_argument("start_time", type=float, help="$(date +%s)")
-parser.add_argument("-i", "--indir", type=str, required=True, help="input data directory")
-parser.add_argument("-o", "--outdir", type=str, required=True, help="output directory")
+parser = argparse.ArgumentParser()
+parser.add_argument("indir", help="input data directory")
+parser.add_argument("outdir", help="output directory")
+parser.add_argument("start_time", help="use $(date +%%s)", type=float)
 parser.add_argument("-c", "--camera", type=str, choices=["b", "r", "z"], help="channel selection", default=None)
 # parser.add_argument("-n", "--nframes", type=int, help="number of input frames to extract")
 # parser.add_argument("-v", "--verbose", action="store_true", help="some flag")

--- a/templates/job.sh
+++ b/templates/job.sh
@@ -25,7 +25,6 @@ module list
 set -x
 {% endif -%}
 
-datadir={{ datadir }}
 let n={{ mpi_ranks_per_node }}*$SLURM_JOB_NUM_NODES
 
 outdir=$SCRATCH/temp-$SLURM_JOB_ID
@@ -38,4 +37,16 @@ source env/bin/activate
 export DESI_LOGLEVEL=error
 export OMP_NUM_THREADS={{ omp_num_threads }}
 
-srun -n $n -c {{ omp_num_threads }} --cpu_bind=cores {{ "shifter" if shifter_image }} python /srv/desi-extract -i $datadir -o $outdir
+srun -n $n -c {{ omp_num_threads }} --cpu_bind=cores \
+{%- if shifter_image %}
+    shifter python /srv/desi-extract \
+{%- else %}
+    python ./desi-extract \
+{%- endif %}
+    -i {{ datadir }} \
+    -o $outdir  \
+{%- if camera %}
+    -c {{ camera }} \
+{%- endif %}
+    $(date +%s)
+

--- a/templates/job.sh
+++ b/templates/job.sh
@@ -43,10 +43,10 @@ srun -n $n -c {{ omp_num_threads }} --cpu_bind=cores \
 {%- else %}
     python ./desi-extract \
 {%- endif %}
-    -i {{ datadir }} \
-    -o $outdir  \
 {%- if camera %}
     -c {{ camera }} \
 {%- endif %}
+    {{ datadir }} \
+    $outdir  \
     $(date +%s)
 


### PR DESCRIPTION
This PR does a little cleanup on imports and sets up timing to follow Pynamic convention.  Also finally adds channel selection to the batch script generator.

* Required argument for `start_time` which should be `$(date +%s)` now
* Grouped imports together except for `mpi4py` one for `argparse`'s sake
* Timing report at end of run with clarifications
* Job template extended for channel support and start time argument