### PR TITLE
adds script to duplicate pix data to enable large runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,8 @@ the logging level before running `desi-extract`:
 export DESI_LOGLEVEL=error
 ```
 
+## Duplicating the dataset
+
+For large runs, it is necessary to duplicate the provided 2019 dataset. You can use the
+script `duplicate-pix-data.py` provided in this repo. Note that you'll need to change
+the path to your copy of the `benchmark-z/pix` directory. 

--- a/README.md
+++ b/README.md
@@ -118,5 +118,29 @@ export DESI_LOGLEVEL=error
 ## Duplicating the dataset
 
 For large runs, it is necessary to duplicate the provided 2019 dataset. You can use the
-script `duplicate-pix-data.py` provided in this repo. Note that you'll need to change
-the path to your copy of the `benchmark-z/pix` directory. 
+script `duplicate-pix-data.py` provided in this repo. 
+
+### Examples
+
+Creating dataset with default script values (years 2020-2023 and days 01-09).
+The user however must always specify their workingdir.
+
+```
+python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest"
+```
+
+Creating only one year
+
+```
+python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest" --create-years=2020
+```
+
+Creating specific years and dates
+using the syntax required by
+ [Click multiple](https://click-docs-cn.readthedocs.io/zh_CN/latest/options.html#multiple-options)
+
+```
+python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest" --create-years=2020 --create-years=2021 --create-days=01 --create-days=02
+``` 
+
+

--- a/README.md
+++ b/README.md
@@ -132,15 +132,13 @@ python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark
 Creating only one year
 
 ```
-python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest" --create-years=2020
+python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest" --create-years 2020
 ```
 
 Creating specific years and dates
-using the syntax required by
- [Click multiple](https://click-docs-cn.readthedocs.io/zh_CN/latest/options.html#multiple-options)
 
 ```
-python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest" --create-years=2020 --create-years=2021 --create-days=01 --create-days=02
-``` 
+python duplicate-pix-data.py --workingdir="/pscratch/sd/s/stephey/desi/benchmark-z-backup/pixtest" --create-years 2020 2021 --create-days 1 2
+```
 
 

--- a/duplicate-pix-data.py
+++ b/duplicate-pix-data.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+
+import os
+import shutil
+import subprocess
+import numpy as np
+
+# EDIT this to point to the location of your benchmark-z/pix directory
+workingdir = '/pscratch/sd/s/stephey/desi/benchmark-z/pix'
+
+start_year = 2019
+create_years = [2020,2021,2022,2023]
+create_days = np.arange(1,10,1)
+
+# this step will duplicate the 2019 data for the requested years
+for year in create_years:
+    for day in create_days:
+        #first let's figure out which dir to copy (always 2019)
+        fixed_year_month_day = [str(start_year), str(10), str(day).zfill(2)]
+        dir_to_copy = ''.join(fixed_year_month_day)
+        #print(dir_to_copy)
+
+        #dir to create
+        new_year_month_day = [str(year), str(10), str(day).zfill(2)]
+        dir_to_create = ''.join(new_year_month_day)
+        #print(dir_to_create)
+
+        #ok ready let's do it
+        copy_path = os.path.join(workingdir, dir_to_copy)
+        print("will copy {}".format(copy_path))
+        new_path = os.path.join(workingdir, dir_to_create)
+        print("will create {}".format(new_path))
+        shutil.copytree(copy_path, new_path)
+
+        print("done")
+
+#nights have been duplicated from the orig 2019 data for 2020-2023
+#for each year, we need to add 1, 2, 3... as a leading digit
+#for all filenames
+
+#it's important that there are no filename collisions within the entire pix dataset
+
+# 2019 is already appropriately named, need to rename copies of 2019 
+month = 10
+# need to zero-pad
+nights = [str(x).zfill(2) for x in create_days]
+print("nights", nights)
+
+#loop over year and add 1, 2, 3 to each increasing year
+#loop over nights within year
+#issue rename command
+#use the unix rename function, not the perl one!
+#rename 0000 0001 *.fits
+
+for i, year in enumerate(create_years, start=1):
+    for night in nights:
+        target_dir = '{}/{}{}{}'.format(workingdir, year, month, night)
+        print("target_dir", target_dir)
+        os.chdir(target_dir)
+
+        rename_command = 'rename 0000 000{} *.fits'.format(i)
+        print("rename_command", rename_command)
+        # dry run
+        subprocess.run(rename_command, shell=True)
+        print("done renaming {}", target_dir)
+
+
+
+

--- a/duplicate-pix-data.py
+++ b/duplicate-pix-data.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 import numpy as np
-import click
+import argparse
 
 def get_month(workingdir, start_year):
     """
@@ -17,7 +17,7 @@ def get_month(workingdir, start_year):
     all_dirnames_flat = [item for sublist in all_dirnames for item in sublist]
     #print("all_dirnames_flat", all_dirnames_flat)
     #now search for dirnames with start_year and take the first hit
-    dirname_match = [s for s in all_dirnames_flat if start_year in s][0]
+    dirname_match = [s for s in all_dirnames_flat if str(start_year) in s][0]
     #parse out the two digits following start_year
     #first start by chopping off the leading year digits
     #this leave the month and the day
@@ -25,7 +25,6 @@ def get_month(workingdir, start_year):
     #then cut off last two digits (this is the day)
     #leaving the month
     month = str(month_day[:-2])
-    print("month:", month)
 
     return month
 
@@ -36,11 +35,11 @@ def dup_start_year(workingdir, start_year, create_years, create_days, month):
     """
     for year in create_years:
         for day in create_days:
-            fixed_year_month_day = [start_year, month, day.zfill(2)]
+            fixed_year_month_day = [str(start_year), str(month), str(day).zfill(2)]
             dir_to_copy = ''.join(fixed_year_month_day)
      
             #dir to create
-            new_year_month_day = [year, month, day.zfill(2)]
+            new_year_month_day = [str(year), str(month), str(day).zfill(2)]
             dir_to_create = ''.join(new_year_month_day)
      
             #ok ready let's do it
@@ -69,21 +68,29 @@ def rename_files(workingdir, create_years, create_days, month):
             #day must be zero-padded
             day_pad = str(day).zfill(2)
             target_dir = '{}/{}{}{}'.format(workingdir, year, month, day_pad)
-            print("target_dir", target_dir)
+            print("will rename ", target_dir)
             os.chdir(target_dir)
     
             rename_command = 'rename 0000 000{} *.fits'.format(i)
             subprocess.run(rename_command, shell=True)
-            print("done renaming {}".format(target_dir))
+            print("done")
     return
 
-@click.command()
-@click.option('--workingdir', required=True, type=str, help="location of benchmark-z/pix directory to augment")
-@click.option('--start-year', type=str, default=2019, help="starting year already in benchmark-z/pix")
-@click.option('--create-years', type=str, default=[2020,2021,2022,2023], multiple=True, help="additional years to create")
-@click.option('--create-days', type=str, default=list(range(1,10)), multiple=True, help="days of month to replicate")
 
-def main(workingdir, start_year, create_years, create_days):
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workingdir", type=str, required=True, help="location of benchmark-z/pix directory to augment")
+    parser.add_argument("--start-year", type=int, default=2019, help="starting year already in benchmark-z/pix")
+    parser.add_argument("--create-years", type=int, nargs="*", default=['2020','2021','2022','2023'], help="additional years to create")
+    parser.add_argument("--create-days", type=int, nargs="*", default=list(range(1,10)), help="days of month to replicate")
+    args = parser.parse_args()
+
+    workingdir = args.workingdir
+    start_year = args.start_year
+    create_years = args.create_years
+    create_days = args.create_days
+
     month = get_month(workingdir, start_year)
     dup_start_year(workingdir, start_year, create_years, create_days, month)
     rename_files(workingdir, create_years, create_days, month)

--- a/duplicate-pix-data.py
+++ b/duplicate-pix-data.py
@@ -4,66 +4,90 @@ import os
 import shutil
 import subprocess
 import numpy as np
+import click
 
-# EDIT this to point to the location of your benchmark-z/pix directory
-workingdir = '/pscratch/sd/s/stephey/desi/benchmark-z/pix'
+def get_month(workingdir, start_year):
+    """
+    determine the month digit from the start-year of workingdir
+    note this must be zero-padded
+    """
+    os.chdir(workingdir)
+    #read first dirname starting with start_year
+    all_dirnames = [x[1] for x in os.walk(workingdir)]
+    all_dirnames_flat = [item for sublist in all_dirnames for item in sublist]
+    #print("all_dirnames_flat", all_dirnames_flat)
+    #now search for dirnames with start_year and take the first hit
+    dirname_match = [s for s in all_dirnames_flat if start_year in s][0]
+    #parse out the two digits following start_year
+    #first start by chopping off the leading year digits
+    #this leave the month and the day
+    month_day = dirname_match.split(str(start_year))[1]
+    #then cut off last two digits (this is the day)
+    #leaving the month
+    month = str(month_day[:-2])
+    print("month:", month)
 
-start_year = 2019
-create_years = [2020,2021,2022,2023]
-create_days = np.arange(1,10,1)
-
-# this step will duplicate the 2019 data for the requested years
-for year in create_years:
-    for day in create_days:
-        #first let's figure out which dir to copy (always 2019)
-        fixed_year_month_day = [str(start_year), str(10), str(day).zfill(2)]
-        dir_to_copy = ''.join(fixed_year_month_day)
-        #print(dir_to_copy)
-
-        #dir to create
-        new_year_month_day = [str(year), str(10), str(day).zfill(2)]
-        dir_to_create = ''.join(new_year_month_day)
-        #print(dir_to_create)
-
-        #ok ready let's do it
-        copy_path = os.path.join(workingdir, dir_to_copy)
-        print("will copy {}".format(copy_path))
-        new_path = os.path.join(workingdir, dir_to_create)
-        print("will create {}".format(new_path))
-        shutil.copytree(copy_path, new_path)
-
-        print("done")
-
-#nights have been duplicated from the orig 2019 data for 2020-2023
-#for each year, we need to add 1, 2, 3... as a leading digit
-#for all filenames
-
-#it's important that there are no filename collisions within the entire pix dataset
-
-# 2019 is already appropriately named, need to rename copies of 2019 
-month = 10
-# need to zero-pad
-nights = [str(x).zfill(2) for x in create_days]
-print("nights", nights)
-
-#loop over year and add 1, 2, 3 to each increasing year
-#loop over nights within year
-#issue rename command
-#use the unix rename function, not the perl one!
-#rename 0000 0001 *.fits
-
-for i, year in enumerate(create_years, start=1):
-    for night in nights:
-        target_dir = '{}/{}{}{}'.format(workingdir, year, month, night)
-        print("target_dir", target_dir)
-        os.chdir(target_dir)
-
-        rename_command = 'rename 0000 000{} *.fits'.format(i)
-        print("rename_command", rename_command)
-        # dry run
-        subprocess.run(rename_command, shell=True)
-        print("done renaming {}", target_dir)
+    return month
 
 
+def dup_start_year(workingdir, start_year, create_years, create_days, month):
+    """
+    # this step will duplicate the start_year data for the requested years
+    """
+    for year in create_years:
+        for day in create_days:
+            fixed_year_month_day = [start_year, month, day.zfill(2)]
+            dir_to_copy = ''.join(fixed_year_month_day)
+     
+            #dir to create
+            new_year_month_day = [year, month, day.zfill(2)]
+            dir_to_create = ''.join(new_year_month_day)
+     
+            #ok ready let's do it
+            copy_path = os.path.join(workingdir, dir_to_copy)
+            print("will copy {}".format(copy_path))
+            new_path = os.path.join(workingdir, dir_to_create)
+            print("will create {}".format(new_path))
+            shutil.copytree(copy_path, new_path)
+     
+            print("done")
+    return
 
 
+def rename_files(workingdir, create_years, create_days, month):
+    """
+    #nights have been duplicated from the start-year
+    #for each year, we need to add 1, 2, 3... as a leading digit
+    #for all filenames for each increasing year
+    #use the unix rename function, not the perl one!
+    #rename 0000 0001 *.fits
+    important that there are no filename collisions in the entire dataset
+    """
+
+    for i, year in enumerate(create_years, start=1):
+        for day in create_days:
+            #day must be zero-padded
+            day_pad = str(day).zfill(2)
+            target_dir = '{}/{}{}{}'.format(workingdir, year, month, day_pad)
+            print("target_dir", target_dir)
+            os.chdir(target_dir)
+    
+            rename_command = 'rename 0000 000{} *.fits'.format(i)
+            subprocess.run(rename_command, shell=True)
+            print("done renaming {}".format(target_dir))
+    return
+
+@click.command()
+@click.option('--workingdir', required=True, type=str, help="location of benchmark-z/pix directory to augment")
+@click.option('--start-year', type=str, default=2019, help="starting year already in benchmark-z/pix")
+@click.option('--create-years', type=str, default=[2020,2021,2022,2023], multiple=True, help="additional years to create")
+@click.option('--create-days', type=str, default=list(range(1,10)), multiple=True, help="days of month to replicate")
+
+def main(workingdir, start_year, create_years, create_days):
+    month = get_month(workingdir, start_year)
+    dup_start_year(workingdir, start_year, create_years, create_days, month)
+    rename_files(workingdir, create_years, create_days, month)
+
+if __name__ == '__main__':
+    main()
+   


### PR DESCRIPTION
Adds a script that can duplicate the existing 2019 pix dataset. This is required to enable larger runs. 

Also updates the README to mention this script and need for duplication. 